### PR TITLE
test: expand UserListPage tests

### DIFF
--- a/src/tests/pages/UserListPage.test.tsx
+++ b/src/tests/pages/UserListPage.test.tsx
@@ -1,79 +1,106 @@
 // UserListPage.test.tsx
-import { render, screen, fireEvent } from '@testing-library/react';
-import { expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
-import UserListPage from '../../pages/UserListPage';
 import { MemoryRouter } from 'react-router-dom';
 
-it('renders the user list page', () => {
-  render(<MemoryRouter><UserListPage /></MemoryRouter>);
-});
-it('shows loading spinner when loading', () => {
-  // Mock useUsersStore to return loading true
-  vi.mock('../../hooks/useUsersStore', () => ({
-    useUsersStore: () => ({
-      users: [],
-      loading: true,
+let mockStore: {
+  users: Array<{ id: number; name: string; email: string }>;
+  loading: boolean;
+  error: string | null;
+  fetchAndSetUsers: ReturnType<typeof vi.fn>;
+};
+
+vi.mock('../../hooks/useUsersStore', () => ({
+  useUsersStore: () => mockStore,
+}));
+
+import UserListPage from '../../pages/UserListPage';
+
+describe('UserListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the user list page', () => {
+    mockStore = { users: [], loading: false, error: null, fetchAndSetUsers: vi.fn() };
+    render(<MemoryRouter><UserListPage /></MemoryRouter>);
+    expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+  });
+
+  it('shows loading spinner when loading', () => {
+    mockStore = { users: [], loading: true, error: null, fetchAndSetUsers: vi.fn() };
+    render(<MemoryRouter><UserListPage /></MemoryRouter>);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows error alert when error exists', () => {
+    mockStore = { users: [], loading: false, error: 'Failed to fetch users', fetchAndSetUsers: vi.fn() };
+    render(<MemoryRouter><UserListPage /></MemoryRouter>);
+    expect(screen.getByText(/failed to fetch users/i)).toBeInTheDocument();
+  });
+
+  it('filters users by search input', async () => {
+    mockStore = {
+      users: [
+        { id: 1, name: 'Alice Smith', email: 'alice@example.com' },
+        { id: 2, name: 'Bob Jones', email: 'bob@example.com' },
+        { id: 3, name: 'Charlie Brown', email: 'charlie@brown.com' },
+      ],
+      loading: false,
       error: null,
       fetchAndSetUsers: vi.fn(),
-    }),
-  }));
-  // Re-import after mocking
-  const UserListPageWithMock = require('../../pages/UserListPage').default;
-  render(<MemoryRouter><UserListPageWithMock /></MemoryRouter>);
-  expect(screen.getByRole('status')).toBeInTheDocument();
-  vi.resetModules();
-});
+    };
+    render(<MemoryRouter><UserListPage /></MemoryRouter>);
 
-it('shows error alert when error exists', () => {
-  vi.mock('../../hooks/useUsersStore', () => ({
-    useUsersStore: () => ({
-      users: [],
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+    expect(screen.getByText('Charlie Brown')).toBeInTheDocument();
+
+    const searchInput = screen.getByPlaceholderText('Search...');
+    fireEvent.change(searchInput, { target: { value: 'bob' } });
+    await waitFor(() =>
+      expect(screen.getByLabelText('User Table')).toHaveAttribute('aria-rowcount', '2')
+    );
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument();
+  });
+
+  it('calls fetchAndSetUsers on mount when store is empty', async () => {
+    const fetchAndSetUsers = vi.fn();
+    mockStore = { users: [], loading: false, error: null, fetchAndSetUsers };
+    render(<MemoryRouter><UserListPage /></MemoryRouter>);
+    await waitFor(() => expect(fetchAndSetUsers).toHaveBeenCalled());
+  });
+
+  it('does not call fetchAndSetUsers when users exist', async () => {
+    const fetchAndSetUsers = vi.fn();
+    mockStore = {
+      users: [{ id: 1, name: 'Jane', email: 'jane@example.com' }],
       loading: false,
-      error: 'Failed to fetch users',
-      fetchAndSetUsers: vi.fn(),
-    }),
-  }));
-  const UserListPageWithMock = require('../../pages/UserListPage').default;
-  render(<MemoryRouter><UserListPageWithMock /></MemoryRouter>);
-  expect(screen.getByText(/failed to fetch users/i)).toBeInTheDocument();
-  vi.resetModules();
-});
+      error: null,
+      fetchAndSetUsers,
+    };
+    render(<MemoryRouter><UserListPage /></MemoryRouter>);
+    await waitFor(() => expect(fetchAndSetUsers).not.toHaveBeenCalled());
+  });
 
-it('filters users by search input', async () => {
-  const users = [
-    { id: 1, name: 'Alice Smith', email: 'alice@example.com' },
-    { id: 2, name: 'Bob Jones', email: 'bob@example.com' },
-    { id: 3, name: 'Charlie Brown', email: 'charlie@brown.com' },
-  ];
-  vi.mock('../../hooks/useUsersStore', () => ({
-    useUsersStore: () => ({
-      users,
+  it('filters users by search input matching email case-insensitively', async () => {
+    mockStore = {
+      users: [
+        { id: 1, name: 'Alice Smith', email: 'alice@example.com' },
+        { id: 2, name: 'Bob Jones', email: 'bob@example.com' },
+        { id: 3, name: 'Charlie Brown', email: 'charlie@brown.com' },
+      ],
       loading: false,
       error: null,
       fetchAndSetUsers: vi.fn(),
-    }),
-  }));
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const UserListPageWithMock = require('../../pages/UserListPage').default;
-  render(<MemoryRouter><UserListPageWithMock /></MemoryRouter>);
-
-  // All users should be present initially
-  expect(screen.getByText('Alice Smith')).toBeInTheDocument();
-  expect(screen.getByText('Bob Jones')).toBeInTheDocument();
-  expect(screen.getByText('Charlie Brown')).toBeInTheDocument();
-
-  // Type in the search input
-  const searchInput = screen.getByRole('search');
-  fireEvent.change(searchInput, { target: { value: 'bob' } });
-
-  // Wait for debounce (250ms)
-  await new Promise((r) => setTimeout(r, 300));
-
-  // Only Bob Jones should be visible
-  expect(screen.getByText('Bob Jones')).toBeInTheDocument();
-  expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument();
-  expect(screen.queryByText('Charlie Brown')).not.toBeInTheDocument();
-
-  vi.resetModules();
+    };
+    render(<MemoryRouter><UserListPage /></MemoryRouter>);
+    const searchInput = screen.getByPlaceholderText('Search...');
+    fireEvent.change(searchInput, { target: { value: 'BROWN.COM' } });
+    await waitFor(() =>
+      expect(screen.getByLabelText('User Table')).toHaveAttribute('aria-rowcount', '2')
+    );
+    expect(screen.getByText('Charlie Brown')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- expand UserListPage tests for loading, error, fetch calls and search filtering

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688e45bbc97c83248c3ee9f3b029d216