### PR TITLE
chore: remove console logs and enforce lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,8 @@ export default tseslint.config([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+    },
   },
 ])

--- a/src/api/apiService.ts
+++ b/src/api/apiService.ts
@@ -19,7 +19,6 @@ class APIService {
       const resp = await axios.get<User[]>(`${this.base}/users`, {
         timeout: 5000,
       });
-      console.log(resp.data);
       return resp.data;
     } catch (e: unknown) {
       if (e instanceof Error) {

--- a/src/components/UserTable/UserTable.tsx
+++ b/src/components/UserTable/UserTable.tsx
@@ -22,8 +22,6 @@ const UserTable: React.FC<Props> = ({ users }) => {
     setOpen(false);
   };
 
- 
-  console.log(users, 'users in table')
 
   const columns: GridColDef[] = [
     { field: 'name', headerName: 'Name', flex: 1, sortable: true },

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"


### PR DESCRIPTION
## Summary
- remove development console logs from API service and user table
- add eslint rule to forbid console logging
- silence react-refresh rule on ui form file

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e4b7764bc83249910598142d06715