### PR TITLE
Add tests for Modal and user store

### DIFF
--- a/src/tests/components/Modal.test.tsx
+++ b/src/tests/components/Modal.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Modal from '../../components/Shared/Modal';
+import type { User } from '../../types';
+import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+const user: User = {
+  id: 1,
+  name: 'Alice Smith',
+  username: 'alice',
+  email: 'alice@example.com',
+  phone: '+1 555-123-4567',
+  website: 'alice.com',
+  address: {
+    street: '123 Main St',
+    suite: 'Apt 1',
+    city: 'Anytown',
+    zipcode: '12345',
+    geo: { lat: '37.7749', lng: '-122.4194' },
+  },
+  company: {
+    name: 'Alice Inc',
+    catchPhrase: 'We do things',
+    bs: 'business stuff',
+  },
+};
+
+describe('Modal', () => {
+  it('renders user details when open', () => {
+    render(<Modal open={true} handleClose={() => {}} user={user} />);
+
+    expect(screen.getByText('User Details')).toBeInTheDocument();
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('@alice')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+  });
+
+  it('calls handleClose when clicking close button', () => {
+    const handleClose = vi.fn();
+    render(<Modal open={true} handleClose={handleClose} user={user} />);
+
+    fireEvent.click(screen.getByText('Close'));
+    expect(handleClose).toHaveBeenCalled();
+  });
+});

--- a/src/tests/hooks/useUsersStore.test.ts
+++ b/src/tests/hooks/useUsersStore.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUsersStore } from '../../hooks/useUsersStore';
+import { apiService } from '../../api/apiService';
+import type { User } from '../../types';
+
+const mockUsers: User[] = [
+  {
+    id: 1,
+    name: 'Alice',
+    username: 'alice',
+    email: 'alice@example.com',
+    phone: '123-456',
+    website: 'alice.com',
+    address: {
+      street: 'Main',
+      suite: 'Apt 1',
+      city: 'Town',
+      zipcode: '12345',
+      geo: { lat: '0', lng: '0' },
+    },
+    company: {
+      name: 'Alice Co',
+      catchPhrase: 'Doing things',
+      bs: 'stuff',
+    },
+  },
+];
+
+beforeEach(() => {
+  useUsersStore.setState({ users: [], loading: false, error: null });
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('useUsersStore', () => {
+  it('fetchAndSetUsers stores fetched users', async () => {
+    vi.spyOn(apiService, 'fetchUsers').mockResolvedValue(mockUsers);
+
+    await useUsersStore.getState().fetchAndSetUsers();
+
+    expect(apiService.fetchUsers).toHaveBeenCalled();
+    expect(useUsersStore.getState().users).toEqual(mockUsers);
+    expect(useUsersStore.getState().loading).toBe(false);
+    expect(useUsersStore.getState().error).toBeNull();
+  });
+
+  it('addUser prepends a user to the store', () => {
+    const existingUser: User = { ...mockUsers[0], id: 2, name: 'Bob' };
+    useUsersStore.setState({ users: [existingUser], loading: false, error: null });
+
+    const newUser: User = { ...mockUsers[0], id: 3, name: 'Carol' };
+    useUsersStore.getState().addUser(newUser);
+
+    const users = useUsersStore.getState().users;
+    expect(users[0]).toEqual(newUser);
+    expect(users).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- test Modal renders details and handles close action
- test user store fetchAndSetUsers and addUser behavior

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688e4be2d8a4832485303eecc6627a29