### PR TITLE
fix: remove static ARIA indices from user table

### DIFF
--- a/src/components/UserTable/UserTable.tsx
+++ b/src/components/UserTable/UserTable.tsx
@@ -22,8 +22,6 @@ const UserTable: React.FC<Props> = ({ users }) => {
     setOpen(false);
   };
 
- 
-  console.log(users, 'users in table')
 
   const columns: GridColDef[] = [
     { field: 'name', headerName: 'Name', flex: 1, sortable: true },
@@ -58,13 +56,10 @@ const UserTable: React.FC<Props> = ({ users }) => {
       getRowId={(row) => row.id}
       onRowClick={(params) => handleClickOpen(params.row)}
       
-      aria-label="User Table"   
+      aria-label="User Table"
       aria-readonly="true"
       aria-colcount={columns.length}
       aria-rowcount={users.length}
-      aria-rowindex={0}
-      aria-colindex={0}
-      aria-rowspan={1}
     />
     <Modal open={open}  handleClose={handleClose} user={selectedUser as User} />
     </Box>


### PR DESCRIPTION
## Summary
- simplify UserTable by removing static ARIA row and column indices, keeping only dynamic counts

## Testing
- `npm test`
- `npm run lint` *(fails: Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components react-refresh/only-export-components in src/components/ui/form.tsx:157)*

------
https://chatgpt.com/codex/tasks/task_e_688e4bbc6cb08324a425d91b8d1a17cd