### PR TITLE
test: fill add user form using user events

### DIFF
--- a/src/tests/e2e/add-user-flow.test.tsx
+++ b/src/tests/e2e/add-user-flow.test.tsx
@@ -6,12 +6,22 @@ import { useUsersStore } from '../../hooks/useUsersStore'
 import AddUserPage from '../../pages/AddUserPage'
 import UserListPage from '../../pages/UserListPage'
 
+let mockFetchAndSetUsers: ReturnType<typeof vi.fn>
+
 beforeEach(() => {
+  mockFetchAndSetUsers = vi.fn().mockResolvedValue(undefined)
+  useUsersStore.persist.setOptions({
+    storage: {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    },
+  })
   useUsersStore.setState({
     users: [],
     loading: false,
     error: null,
-    fetchAndSetUsers: vi.fn().mockResolvedValue(undefined),
+    fetchAndSetUsers: mockFetchAndSetUsers,
   })
   localStorage.clear()
 })
@@ -37,25 +47,30 @@ test('user can add a new entry via form and see it in the user list', async () =
     </MemoryRouter>
   )
 
+  // ensure store hydration is complete before interactions
+  if (!useUsersStore.persist.hasHydrated()) {
+    await new Promise((resolve) => useUsersStore.persist.onFinishHydration(resolve))
+  }
+
   await user.click(screen.getByRole('link', { name: /add user/i }))
   await screen.findByTestId('username')
 
-  useUsersStore.getState().addUser({
-    id: '1',
-    name: 'John',
-    username: 'johndoe',
-    email: 'john@example.com',
-    phone: '+1 555-123-4567',
-    website: 'https://johndoe.com',
-    address: { street: '123 Main St', suite: 'Apt 1', city: 'Anytown', zipcode: '12345', geo: { lat: '34.0522', lng: '-118.2437' } },
-    company: { name: 'Acme Corp', catchPhrase: 'Innovate your world', bs: 'empower synergistic solutions' },
-  })
+  await user.type(screen.getByTestId('username'), 'johndoe')
+  await user.type(screen.getByTestId('name'), 'John')
+  await user.type(screen.getByTestId('email'), 'john@example.com')
+  await user.type(screen.getByTestId('phone'), '+1 555-123-4567')
+  await user.type(screen.getByTestId('website'), 'https://johndoe.com')
+  await user.type(screen.getByTestId('street'), '123 Main St')
+  await user.type(screen.getByTestId('suite'), 'Apt 1')
+  await user.type(screen.getByTestId('city'), 'Anytown')
+  await user.type(screen.getByTestId('zipcode'), '12345')
+  await user.type(screen.getByTestId('latitude'), '34.0522')
+  await user.type(screen.getByTestId('longitude'), '-118.2437')
+  await user.type(screen.getByTestId('company-name'), 'Acme Corp')
+  await user.type(screen.getByTestId('catch-phrase'), 'Innovate your world')
+  await user.type(screen.getByTestId('bs'), 'empower synergistic solutions')
 
-  vi.useFakeTimers()
   await user.click(screen.getByTestId('submit'))
-  vi.advanceTimersByTime(2000)
-  vi.useRealTimers()
 
-  expect(await screen.findByText('John')).toBeInTheDocument()
+  expect(await screen.findByText('John', undefined, { timeout: 3000 })).toBeInTheDocument()
 })
-


### PR DESCRIPTION
## Summary
- expand add-user flow test to type into each field and submit the form

## Testing
- `npm test src/tests/e2e/add-user-flow.test.tsx` *(fails: Unable to find an element with the text 'John')*

------
https://chatgpt.com/codex/tasks/task_e_688e797e93388324bada7083150eb64e