### PR TITLE
fix: advance timers in add-user e2e test

### DIFF
--- a/src/tests/e2e/add-user-flow.test.tsx
+++ b/src/tests/e2e/add-user-flow.test.tsx
@@ -72,6 +72,7 @@ test('user can add a new entry via form and see it in the user list', async () =
   await user.type(screen.getByTestId('bs'), 'empower synergistic solutions')
 
   await user.click(screen.getByTestId('submit'))
+  vi.advanceTimersByTime(2000) // run navigation timeout
 
   expect(await screen.findByText('John', undefined, { timeout: 3000 })).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- ensure add-user e2e test advances fake timers after submit so navigation timeout executes

## Testing
- `npm test src/tests/e2e/add-user-flow.test.tsx` *(fails: Test timed out in 5000ms)*

------
https://chatgpt.com/codex/tasks/task_e_688e7fc3c3088324a33dba46ead0cb11