### PR TITLE
test: increase timeout for e2e user flow

### DIFF
--- a/src/tests/e2e/add-user-flow.test.tsx
+++ b/src/tests/e2e/add-user-flow.test.tsx
@@ -75,4 +75,4 @@ test('user can add a new entry via form and see it in the user list', async () =
   vi.advanceTimersByTime(2000) // run navigation timeout
 
   expect(await screen.findByText('John', undefined, { timeout: 3000 })).toBeInTheDocument()
-})
+}, 10_000)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     globals: true,
     css: true,
     setupFiles: ['./src/tests/setup.ts'],
+    testTimeout: 10_000,
   },
   // Mock CSS imports
   define: {


### PR DESCRIPTION
## Summary
- increase timeout to 10s in add-user-flow e2e test
- configure global 10s testTimeout for vitest

## Testing
- `npm test` *(fails: Error: Test timed out in 10000ms)*

------
https://chatgpt.com/codex/tasks/task_e_688e8532f22883249a2a8bfd8ff720e4