### PR TITLE
test: await username field in add user flow

### DIFF
--- a/src/tests/e2e/add-user-flow.test.tsx
+++ b/src/tests/e2e/add-user-flow.test.tsx
@@ -54,9 +54,9 @@ test('user can add a new entry via form and see it in the user list', async () =
   }
 
   await user.click(screen.getByRole('link', { name: /add user/i }))
-  screen.getByTestId('username')
+  const usernameInput = await screen.findByTestId('username')
 
-  await user.type(screen.getByTestId('username'), 'johndoe')
+  await user.type(usernameInput, 'johndoe')
   await user.type(screen.getByTestId('name'), 'John')
   await user.type(screen.getByTestId('email'), 'john@example.com')
   await user.type(screen.getByTestId('phone'), '+1 555-123-4567')


### PR DESCRIPTION
## Summary
- await username input to appear before typing in add-user flow test

## Testing
- `npm run lint src/tests/e2e/add-user-flow.test.tsx`
- `npm test src/tests/e2e/add-user-flow.test.tsx` *(fails: Test timed out in 5000ms)*

------
https://chatgpt.com/codex/tasks/task_e_688e852fdf0c8324bbac229e8631e06b